### PR TITLE
Print environment variables one per line.

### DIFF
--- a/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
+++ b/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
@@ -361,8 +361,7 @@ public class ResourcePolicy {
 
         String command = scheduler.conf.get("mapred.mesos.executor.command");
         if (command == null || command.equals("")) {
-          command = "echo $(env) ; " +
-              " ./bin/hadoop  org.apache.hadoop.mapred.MesosExecutor";
+          command = "env ; ./bin/hadoop org.apache.hadoop.mapred.MesosExecutor";
         }
 
         commandInfo = CommandInfo.newBuilder()


### PR DESCRIPTION
Previous example would print `ENV` all one one line, making it harder to read, and would have allowed shell expansion, hindering debugging.
