### PR TITLE
Fixed the tracking of active tasks.

### DIFF
--- a/src/main/java/org/apache/hadoop/mapred/MesosScheduler.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosScheduler.java
@@ -380,6 +380,11 @@ public class MesosScheduler extends TaskScheduler implements Scheduler {
       case TASK_STAGING:
       case TASK_STARTING:
       case TASK_RUNNING:
+        for (MesosTracker tracker : mesosTrackers.values()) {
+          if (tracker.taskId.equals(taskStatus.getTaskId())) {
+            tracker.active = true;
+          }
+        }
         break;
       default:
         LOG.error("Unexpected TaskStatus: " + taskStatus.getState().name());

--- a/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
+++ b/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
@@ -100,9 +100,10 @@ public class ResourcePolicy {
 
       HttpHost host = new HttpHost(status.getHost(), status.getHttpPort());
       if (scheduler.mesosTrackers.containsKey(host)) {
-        scheduler.mesosTrackers.get(host).active = true;
-        idleMapSlots += status.getAvailableMapSlots();
-        idleReduceSlots += status.getAvailableReduceSlots();
+        if (scheduler.mesosTrackers.get(host).active) {
+          idleMapSlots += status.getAvailableMapSlots();
+          idleReduceSlots += status.getAvailableReduceSlots();
+        }
       }
     }
 


### PR DESCRIPTION
The mesos scheduler was previously not terminating mesos tasks that belonged to jobs that were killed before all their map jobs were submitted. This happened because the tasks were not considered active at the time the job was killed. To resolve this, tasks are now set as active when a TASK_RUNNING status is received. 

Logs (with extra output) from before the fix:
2014-02-06 14:25:19,884 INFO org.apache.hadoop.mapred.MesosScheduler: Added job job_201402051747_0003
2014-02-06 14:25:19,884 INFO org.apache.hadoop.mapred.MesosScheduler: job id: 3
2014-02-06 14:25:19,884 INFO org.apache.hadoop.mapred.MesosScheduler: job idnt: 201402051747
2014-02-06 14:25:25,918 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_4 to TASK_RUNNING with message 
2014-02-06 14:25:26,426 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_5 to TASK_RUNNING with message 
2014-02-06 14:25:26,761 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_7 to TASK_RUNNING with message 
2014-02-06 14:25:27,818 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_6 to TASK_RUNNING with message 
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Completed job : job_201402051747_0003
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Number of trackers: 4
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Tracker contains job: true
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Tracker New job: true
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: job id: 3
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: job idnt: 201402051747
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Mesos Tracker active:false
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: num jobs:0
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Tracker contains job: true
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Tracker New job: true
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: job id: 3
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: job idnt: 201402051747
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Mesos Tracker active:false
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: num jobs:0
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Tracker contains job: true
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Tracker New job: true
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: job id: 3
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: job idnt: 201402051747
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Mesos Tracker active:false
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: num jobs:0
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Tracker contains job: true
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Tracker New job: true
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: job id: 3
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: job idnt: 201402051747
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: Mesos Tracker active:false
2014-02-06 14:26:21,444 INFO org.apache.hadoop.mapred.MesosScheduler: num jobs:0

Logs after the fix:
2014-02-06 14:41:25,632 INFO org.apache.hadoop.mapred.MesosScheduler: Starting MesosScheduler
2014-02-06 14:41:26,182 INFO org.apache.hadoop.mapred.MesosScheduler: Registered as 201402051659-1679075520-5050-7965-0003 with master id: "201402051659-1679075520-5050-7965"
2014-02-06 14:42:21,448 INFO org.apache.hadoop.mapred.MesosScheduler: Added job job_201402061441_0001
2014-02-06 14:42:27,889 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_2 to TASK_RUNNING with message 
2014-02-06 14:42:28,135 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_1 to TASK_RUNNING with message 
2014-02-06 14:42:28,389 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_3 to TASK_RUNNING with message 
2014-02-06 14:42:28,392 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_0 to TASK_RUNNING with message 
2014-02-06 14:43:17,883 INFO org.apache.hadoop.mapred.MesosScheduler: Completed job : job_201402061441_0001
2014-02-06 14:43:17,883 INFO org.apache.hadoop.mapred.MesosScheduler: Killing Mesos task: value: "Task_Tracker_0"
2014-02-06 14:43:17,884 INFO org.apache.hadoop.mapred.MesosScheduler: Killing Mesos task: value: "Task_Tracker_1"
2014-02-06 14:43:17,885 INFO org.apache.hadoop.mapred.MesosScheduler: Killing Mesos task: value: "Task_Tracker_3"
2014-02-06 14:43:17,885 INFO org.apache.hadoop.mapred.MesosScheduler: Killing Mesos task: value: "Task_Tracker_2"
2014-02-06 14:43:19,581 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_1 to TASK_FINISHED with message 
2014-02-06 14:43:19,621 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_2 to TASK_FINISHED with message 
2014-02-06 14:43:19,847 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_3 to TASK_FINISHED with message 
2014-02-06 14:43:20,066 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_0 to TASK_FINISHED with message 
2014-02-06 14:44:20,698 INFO org.apache.hadoop.mapred.MesosScheduler: Added job job_201402061441_0002
2014-02-06 14:44:25,068 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_4 to TASK_RUNNING with message 
2014-02-06 14:44:30,953 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_5 to TASK_RUNNING with message 
2014-02-06 14:44:49,396 INFO org.apache.hadoop.mapred.MesosScheduler: Completed job : job_201402061441_0002
2014-02-06 14:44:49,396 INFO org.apache.hadoop.mapred.MesosScheduler: Killing Mesos task: value: "Task_Tracker_5"
2014-02-06 14:44:49,397 INFO org.apache.hadoop.mapred.MesosScheduler: Killing Mesos task: value: "Task_Tracker_4"
2014-02-06 14:44:49,548 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_5 to TASK_FINISHED with message 
2014-02-06 14:44:50,888 INFO org.apache.hadoop.mapred.MesosScheduler: Status update of Task_Tracker_4 to TASK_FINISHED with message 
