### PR TITLE
Update shade plugin to fix compile error with new version of Maven.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.0</version>
+                <version>2.1</version>
                 <configuration>
                     <filters>
                         <filter>


### PR DESCRIPTION
Details: https://issues.apache.org/jira/browse/CAMEL-6587
