### PR TITLE
Don't set the mapred.job.tracker config option

### DIFF
--- a/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
+++ b/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
@@ -394,9 +394,6 @@ public class ResourcePolicy {
         // override properties as appropriate for the TaskTracker.
         Configuration overrides = new Configuration(scheduler.conf);
 
-        overrides.set("mapred.job.tracker",
-            jobTrackerAddress.getHostName() + ':' + jobTrackerAddress.getPort());
-
         overrides.set("mapred.task.tracker.http.address",
             httpAddress.getHostName() + ':' + httpAddress.getPort());
 


### PR DESCRIPTION
Configuring this option causes issues with track tracker connectivity when using the HA JobTracker configuration mode. I assume the reason this option is set is due to the fact hadoop doesn't require you configure this option on the actual JobTracker, only the clients (and task trackers)?

This probably isn't the right fix, however I wanted to open up discussion. Perhaps we could only set the option if it's not currently configured on the config object?

Would appreciate any thoughts, @brndnmtthws?
