### PR TITLE
Idle TaskTrackers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 .vimrc
 .idea/
 *.iml
+*-pom.xml

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Hadoop on Mesos
 
 #### Overview ####
 
-To run _Hadoop on Mesos_ you need to add the `hadoop-mesos-0.0.9.jar`
+To run _Hadoop on Mesos_ you need to add the `hadoop-mesos-0.1.0.jar`
 library to your Hadoop distribution (any distribution that uses protobuf > 2.5.0)
 and set some new configuration properties. Read on for details.
 
@@ -23,13 +23,13 @@ install `libsnappy`.  The [`snappy-java`][snappy-java] package also includes a b
 
 #### Build ####
 
-You can build `hadoop-mesos-0.0.9.jar` using Maven:
+You can build `hadoop-mesos-0.1.0.jar` using Maven:
 
 ```shell
 mvn package
 ```
 
-If successful, the JAR will be at `target/hadoop-mesos-0.0.9.jar`.
+If successful, the JAR will be at `target/hadoop-mesos-0.1.0.jar`.
 
 > NOTE: If you want to build against a different version of Mesos than
 > the default you'll need to update `mesos-version` in `pom.xml`.
@@ -51,10 +51,10 @@ tar zxf hadoop-2.5.0-cdh5.2.0.tar.gz
 
 > **Take note**, the extracted directory is `hadoop-2.5.0-cdh5.2.0`.
 
-Now copy `hadoop-mesos-0.0.9.jar` into the `share/hadoop/common/lib` folder.
+Now copy `hadoop-mesos-0.1.0.jar` into the `share/hadoop/common/lib` folder.
 
 ```shell
-cp /path/to/hadoop-mesos-0.0.9.jar hadoop-2.5.0-cdh5.2.0/share/hadoop/common/lib/
+cp /path/to/hadoop-mesos-0.1.0.jar hadoop-2.5.0-cdh5.2.0/share/hadoop/common/lib/
 ```
 
 Since CDH5 includes both MRv1 and MRv2 (YARN) and is configured for YARN by
@@ -182,6 +182,5 @@ This feature can be especially useful if your hadoop jobs have software dependen
 ```
 
 _Please email user@mesos.apache.org with questions!_
-
 
 ----------

--- a/configuration.md
+++ b/configuration.md
@@ -161,6 +161,24 @@ default values.
     </description>
   </property>
 
+  <!-- TaskTracker Idle Slots Revocation -->
+  <property>
+    <name>mapred.mesos.tracker.idle.interval</name>
+    <value>5</value>
+    <description>
+      Internal (in seconds) to check for TaskTrackers that have idle
+      slots. Default is 5 seconds.
+    </description>
+  </property>
+  <property>
+    <name>mapred.mesos.tracker.idle.checks</name>
+    <value>5</value>
+    <description>
+      After this many successful idle checks (meaning all slots *are* idle) the
+      slots will be revoked from the TaskTracker.
+    </description>
+  </property>
+
   <!-- Metrics -->
   <property>
     <name>mapred.mesos.metrics.enabled</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.apache.mesos</groupId>
     <artifactId>hadoop-mesos</artifactId>
-    <version>0.0.9</version>
+    <version>0.1.0</version>
 
     <properties>
         <encoding>UTF-8</encoding>

--- a/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
@@ -11,10 +11,20 @@ import org.apache.mesos.Protos.TaskStatus;
 
 import java.io.*;
 
+import java.lang.reflect.Field;
+import java.lang.ReflectiveOperationException;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
 public class MesosExecutor implements Executor {
   public static final Log LOG = LogFactory.getLog(MesosExecutor.class);
   private SlaveInfo slaveInfo;
   private TaskTracker taskTracker;
+
+  protected final ScheduledExecutorService timerScheduler =
+       Executors.newScheduledThreadPool(1);
 
   public static void main(String[] args) {
     MesosExecutorDriver driver = new MesosExecutorDriver(new MesosExecutor());
@@ -37,10 +47,8 @@ public class MesosExecutor implements Executor {
       conf.writeXml(writer);
       writer.flush();
       String xml = writer.getBuffer().toString();
-      String xmlFormatted =
-          org.apache.mesos.hadoop.Utils.formatXml(xml);
       LOG.info("XML Configuration received:\n" +
-          xmlFormatted);
+               org.apache.mesos.hadoop.Utils.formatXml(xml));
     } catch (Exception e) {
       LOG.warn("Failed to output configuration as XML.", e);
     }
@@ -123,14 +131,16 @@ public class MesosExecutor implements Executor {
   }
 
   @Override
-  public void killTask(ExecutorDriver driver, TaskID taskId) {
+  public void killTask(final ExecutorDriver driver, final TaskID taskId) {
     LOG.info("Killing task : " + taskId.getValue());
-    try {
-      taskTracker.shutdown();
-    } catch (IOException e) {
-      LOG.error("Failed to shutdown TaskTracker", e);
-    } catch (InterruptedException e) {
-      LOG.error("Failed to shutdown TaskTracker", e);
+    if (taskTracker != null) {
+        LOG.info("Revoking task tracker map/reduce slots");
+        revokeSlots();
+
+        driver.sendStatusUpdate(TaskStatus.newBuilder()
+            .setTaskId(taskId)
+            .setState(TaskState.TASK_FINISHED)
+            .build());
     }
   }
 
@@ -158,5 +168,86 @@ public class MesosExecutor implements Executor {
   @Override
   public void shutdown(ExecutorDriver d) {
     LOG.info("Executor asked to shutdown");
+  }
+
+  public void revokeSlots() {
+    if (taskTracker == null) {
+      LOG.error("Task tracker is not initialized");
+      return;
+    }
+
+    int mapSlotsToRevoke = taskTracker.getJobConf().getInt("mapred.tasktracker.map.tasks.revoke", 0);
+    int reduceSlotsToRevoke = taskTracker.getJobConf().getInt("mapred.tasktracker.reduce.tasks.revoke", 0);
+
+    int maxMapSlots = taskTracker.getMaxCurrentMapTasks() - mapSlotsToRevoke;
+    int maxReduceSlots = taskTracker.getMaxCurrentReduceTasks() - reduceSlotsToRevoke;
+
+    // TODO(tarnfeld): Sanity check that it's safe for us to change the slots.
+    // Be sure there's nothing running and nothing in the launcher queue.
+
+    // If we expect to have no slots, let's go ahead and terminate the task launchers
+    if (maxMapSlots == 0) {
+      try {
+        Field launcherField = taskTracker.getClass().getDeclaredField("mapLauncher");
+        launcherField.setAccessible(true);
+
+        // Kill the current map task launcher
+        ((TaskTracker.TaskLauncher) launcherField.get(taskTracker)).interrupt();
+      } catch (ReflectiveOperationException e) {
+        LOG.fatal("Failed updating map slots due to error with reflection", e);
+      }
+    }
+
+    if (maxReduceSlots == 0) {
+      try {
+        Field launcherField = taskTracker.getClass().getDeclaredField("reduceLauncher");
+        launcherField.setAccessible(true);
+
+        // Kill the current reduce task launcher
+        ((TaskTracker.TaskLauncher) launcherField.get(taskTracker)).interrupt();
+      } catch (ReflectiveOperationException e) {
+        LOG.fatal("Failed updating reduce slots due to error with reflection", e);
+      }
+    }
+
+    // Configure the new slot counts on the task tracker
+    taskTracker.setMaxMapSlots(maxMapSlots);
+    taskTracker.setMaxReduceSlots(maxReduceSlots);
+
+    // If we have zero slots left, commit suicide when no jobs are running
+    if (maxMapSlots + maxReduceSlots == 0) {
+      scheduleSuicideTimer();
+    }
+  }
+
+  protected void scheduleSuicideTimer() {
+    timerScheduler.schedule(new Runnable() {
+      @Override
+      public void run() {
+        if (taskTracker == null) {
+          return;
+        }
+
+        LOG.info("Checking to see if TaskTracker has no running jobs");
+        int runningJobs = taskTracker.runningJobs.size();
+
+        // Check to see if the number of running jobs on the task tracker is zero
+        if (runningJobs == 0) {
+          LOG.warn("TaskTracker has zero jobs running, terminating");
+
+          try {
+            taskTracker.shutdown();
+          } catch (IOException e) {
+            LOG.error("Failed to shutdown TaskTracker", e);
+          } catch (InterruptedException e) {
+            LOG.error("Failed to shutdown TaskTracker", e);
+          }
+        }
+        else {
+          LOG.info("TaskTracker has " + runningJobs + " jobs running");
+          scheduleSuicideTimer();
+        }
+      }
+    }, 1000, TimeUnit.MILLISECONDS);
   }
 }

--- a/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
@@ -222,7 +222,7 @@ public class MesosExecutor implements Executor {
     taskTracker.setMaxReduceSlots(maxReduceSlots);
 
     // If we have zero slots left, commit suicide when no jobs are running
-    if (maxMapSlots + maxReduceSlots == 0) {
+    if ((maxMapSlots + maxReduceSlots) == 0) {
       scheduleSuicideTimer();
     }
   }

--- a/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
@@ -136,11 +136,6 @@ public class MesosExecutor implements Executor {
     if (taskTracker != null) {
         LOG.info("Revoking task tracker map/reduce slots");
         revokeSlots();
-
-        driver.sendStatusUpdate(TaskStatus.newBuilder()
-            .setTaskId(taskId)
-            .setState(TaskState.TASK_FINISHED)
-            .build());
     }
   }
 

--- a/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
@@ -195,7 +195,9 @@ public class MesosExecutor implements Executor {
         launcherField.setAccessible(true);
 
         // Kill the current map task launcher
-        ((TaskTracker.TaskLauncher) launcherField.get(taskTracker)).interrupt();
+        TaskTracker.TaskLauncher launcher = ((TaskTracker.TaskLauncher) launcherField.get(taskTracker));
+        launcher.notifySlots();
+        launcher.interrupt();
       } catch (ReflectiveOperationException e) {
         LOG.fatal("Failed updating map slots due to error with reflection", e);
       }
@@ -207,7 +209,9 @@ public class MesosExecutor implements Executor {
         launcherField.setAccessible(true);
 
         // Kill the current reduce task launcher
-        ((TaskTracker.TaskLauncher) launcherField.get(taskTracker)).interrupt();
+        TaskTracker.TaskLauncher launcher = ((TaskTracker.TaskLauncher) launcherField.get(taskTracker));
+        launcher.notifySlots();
+        launcher.interrupt();
       } catch (ReflectiveOperationException e) {
         LOG.fatal("Failed updating reduce slots due to error with reflection", e);
       }

--- a/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
@@ -231,12 +231,12 @@ public class MesosExecutor implements Executor {
           return;
         }
 
-        LOG.info("Checking to see if TaskTracker has no running tasks");
-        int runningTasks = taskTracker.runningTasks.size();
+        LOG.info("Checking to see if TaskTracker has no running jobs");
+        int runningJobs = taskTracker.runningJobs.size();
 
         // Check to see if the number of running jobs on the task tracker is zero
-        if (runningTasks == 0) {
-          LOG.warn("TaskTracker has zero tasks running, terminating");
+        if (runningJobs == 0) {
+          LOG.warn("TaskTracker has zero jobs running, terminating");
 
           try {
             taskTracker.shutdown();
@@ -247,7 +247,7 @@ public class MesosExecutor implements Executor {
           }
         }
         else {
-          LOG.info("TaskTracker has " + runningTasks + " jobs running");
+          LOG.info("TaskTracker has " + runningJobs + " jobs running");
           scheduleSuicideTimer();
         }
       }

--- a/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
@@ -231,12 +231,12 @@ public class MesosExecutor implements Executor {
           return;
         }
 
-        LOG.info("Checking to see if TaskTracker has no running jobs");
-        int runningJobs = taskTracker.runningJobs.size();
+        LOG.info("Checking to see if TaskTracker has no running tasks");
+        int runningTasks = taskTracker.runningTasks.size();
 
         // Check to see if the number of running jobs on the task tracker is zero
-        if (runningJobs == 0) {
-          LOG.warn("TaskTracker has zero jobs running, terminating");
+        if (runningTasks == 0) {
+          LOG.warn("TaskTracker has zero tasks running, terminating");
 
           try {
             taskTracker.shutdown();
@@ -247,7 +247,7 @@ public class MesosExecutor implements Executor {
           }
         }
         else {
-          LOG.info("TaskTracker has " + runningJobs + " jobs running");
+          LOG.info("TaskTracker has " + runningTasks + " jobs running");
           scheduleSuicideTimer();
         }
       }

--- a/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
@@ -134,8 +134,19 @@ public class MesosExecutor implements Executor {
   public void killTask(final ExecutorDriver driver, final TaskID taskId) {
     LOG.info("Killing task : " + taskId.getValue());
     if (taskTracker != null) {
-        LOG.info("Revoking task tracker map/reduce slots");
-        revokeSlots();
+      LOG.info("Revoking task tracker map/reduce slots");
+      revokeSlots();
+
+      // Send the TASK_FINISHED status
+      new Thread("TaskFinishedUpdate") {
+        @Override
+        public void run() {
+          driver.sendStatusUpdate(TaskStatus.newBuilder()
+            .setTaskId(taskId)
+            .setState(TaskState.TASK_FINISHED)
+            .build());
+        }
+      }.start();
     }
   }
 

--- a/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
@@ -171,11 +171,8 @@ public class MesosExecutor implements Executor {
       return;
     }
 
-    int mapSlotsToRevoke = taskTracker.getJobConf().getInt("mapred.tasktracker.map.tasks.revoke", 0);
-    int reduceSlotsToRevoke = taskTracker.getJobConf().getInt("mapred.tasktracker.reduce.tasks.revoke", 0);
-
-    int maxMapSlots = taskTracker.getMaxCurrentMapTasks() - mapSlotsToRevoke;
-    int maxReduceSlots = taskTracker.getMaxCurrentReduceTasks() - reduceSlotsToRevoke;
+    int maxMapSlots = 0;
+    int maxReduceSlots = 0;
 
     // TODO(tarnfeld): Sanity check that it's safe for us to change the slots.
     // Be sure there's nothing running and nothing in the launcher queue.

--- a/src/main/java/org/apache/hadoop/mapred/MesosScheduler.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosScheduler.java
@@ -45,6 +45,9 @@ public class MesosScheduler extends TaskScheduler implements Scheduler {
   // giving up.
   public static final long LAUNCH_TIMEOUT_MS = 300000; // 5 minutes
   public static final long PERIODIC_MS = 300000; // 5 minutes
+  public static final long DEFAULT_IDLE_CHECK_INTERVAL = 5; // 5 seconds
+  // Destroy task trackers after being idle for N idle checks
+  public static final long DEFAULT_IDLE_REVOCATION_CHECKS = 5;
   private SchedulerDriver driver;
 
   protected TaskScheduler taskScheduler;

--- a/src/main/java/org/apache/hadoop/mapred/MesosScheduler.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosScheduler.java
@@ -36,8 +36,9 @@ public class MesosScheduler extends TaskScheduler implements Scheduler {
   public static final double SLOT_CPUS_DEFAULT = 1; // 1 cores.
   public static final int SLOT_DISK_DEFAULT = 1024; // 1 GB.
   public static final int SLOT_JVM_HEAP_DEFAULT = 1024; // 1024MB.
-  public static final double TASKTRACKER_CPUS = 1.0; // 1 core.
+  public static final double TASKTRACKER_CPUS_DEFAULT = 1.0; // 1 core.
   public static final int TASKTRACKER_MEM_DEFAULT = 1024; // 1 GB.
+  public static final int TASKTRACKER_DISK_DEFAULT = 1024; // 1 GB.
   // The default behavior in Hadoop is to use 4 slots per TaskTracker:
   public static final int MAP_SLOTS_DEFAULT = 2;
   public static final int REDUCE_SLOTS_DEFAULT = 2;

--- a/src/main/java/org/apache/hadoop/mapred/MesosTracker.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosTracker.java
@@ -27,7 +27,6 @@ public class MesosTracker {
   public volatile long idleCheckMax = 0;
   public volatile boolean active = false; // Set once tracked by the JobTracker.
   public volatile boolean stopped = false;
-  public volatile boolean killed = false;
   public volatile MesosScheduler scheduler;
   // Tracks Hadoop jobs running on the tracker.
   public Set<JobID> jobs = Collections.newSetFromMap(new ConcurrentHashMap<JobID, Boolean>());
@@ -96,9 +95,8 @@ public class MesosTracker {
     scheduler.scheduleTimer(new Runnable() {
       @Override
       public void run() {
-        // We're not interested if the task tracker has been stopped or slots
-        // have already been revoked.
-        if (MesosTracker.this.stopped || MesosTracker.this.killed) {
+        // We're not interested if the task tracker has been stopped.
+        if (MesosTracker.this.stopped) {
           return;
         }
 

--- a/src/main/java/org/apache/hadoop/mapred/MesosTracker.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosTracker.java
@@ -138,7 +138,9 @@ public class MesosTracker {
           LOG.info("TaskTracker appears idle right now: " + MesosTracker.this.host);
           MesosTracker.this.idleCounter += 1;
         } else {
-          LOG.debug("TaskTracker is no longer idle: " + MesosTracker.this.host);
+          if (MesosTracker.this.idleCounter > 0) {
+            LOG.info("TaskTracker is no longer idle: " + MesosTracker.this.host);
+          }
           MesosTracker.this.idleCounter = 0;
         }
 

--- a/src/main/java/org/apache/hadoop/mapred/MesosTracker.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosTracker.java
@@ -115,6 +115,7 @@ public class MesosTracker {
         if (MesosTracker.this.idleCounter >= MesosTracker.this.idleCheckMax) {
           LOG.info("Killing idle tasktracker: " + MesosTracker.this.host);
           MesosTracker.this.scheduler.killTracker(MesosTracker.this);
+          scheduleIdleCheck();
           return;
         }
 

--- a/src/main/java/org/apache/hadoop/mapred/MesosTracker.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosTracker.java
@@ -113,6 +113,7 @@ public class MesosTracker {
         // but are completely idle. The MesosScheduler is in charge of destroying
         // task trackers that are not handling any jobs, so we can leave those alone.
         if (MesosTracker.this.idleCounter >= MesosTracker.this.idleCheckMax) {
+          LOG.info("Killing idle tasktracker: " + MesosTracker.this.host);
           MesosTracker.this.scheduler.killTracker(MesosTracker.this);
           return;
         }

--- a/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
+++ b/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
@@ -495,7 +495,7 @@ public class ResourcePolicy {
         // Create the TaskTracker TaskInfo
         TaskInfo trackerTaskInfo = TaskInfo
             .newBuilder()
-            .setName("tasktracker_" + taskId.getValue())
+            .setName(taskId.getValue())
             .setTaskId(taskId)
             .setSlaveId(offer.getSlaveId())
             .addResources(

--- a/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
+++ b/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
@@ -78,6 +78,7 @@ public class ResourcePolicy {
     int pendingReduces = 0;
     int runningMaps = 0;
     int runningReduces = 0;
+
     for (JobInProgress progress : jobsInProgress) {
       // JobStatus.pendingMaps/Reduces may return the wrong value on
       // occasion.  This seems to be safer.
@@ -85,6 +86,12 @@ public class ResourcePolicy {
       pendingReduces += scheduler.getPendingTasks(progress.getTasks(TaskType.REDUCE));
       runningMaps += progress.runningMaps();
       runningReduces += progress.runningReduces();
+
+      // If the task is waiting to launch the cleanup task, let us make sure we have
+      // capacity to run the task.
+      if (!progress.isCleanupLaunched()) {
+        pendingMaps += scheduler.getPendingTasks(progress.getTasks(TaskType.JOB_CLEANUP));
+      }
     }
 
     // Mark active (heartbeated) TaskTrackers and compute idle slots.

--- a/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
+++ b/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
@@ -64,11 +64,11 @@ public class ResourcePolicy {
         (MesosScheduler.JVM_MEM_OVERHEAD_PERCENT_DEFAULT + 1));
 
     containerCpus = scheduler.conf.getFloat("mapred.mesos.tasktracker.cpus",
-        (float) MesosScheduler.TASKTRACKER_CPUS);
+        (float) MesosScheduler.TASKTRACKER_CPUS_DEFAULT);
+    containerDisk = scheduler.conf.getInt("mapred.mesos.tasktracker.disk",
+        MesosScheduler.TASKTRACKER_DISK_DEFAULT);
 
     containerMem = tasktrackerMem;
-    containerDisk = 0;
-
   }
 
   public void computeNeededSlots(List<JobInProgress> jobsInProgress,

--- a/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
+++ b/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
@@ -476,7 +476,7 @@ public class ResourcePolicy {
                     .setName("mem")
                     .setType(Value.Type.SCALAR)
                     .setRole(memRole)
-                    .setScalar(Value.Scalar.newBuilder().setValue(taskMem)))
+                    .setScalar(Value.Scalar.newBuilder().setValue(containerMem)))
             .addResources(
                 Resource
                     .newBuilder()
@@ -527,6 +527,13 @@ public class ResourcePolicy {
                     .setType(Value.Type.SCALAR)
                     .setRole(cpuRole)
                     .setScalar(Value.Scalar.newBuilder().setValue(taskCpus - containerCpus)))
+            .addResources(
+                Resource
+                    .newBuilder()
+                    .setName("mem")
+                    .setType(Value.Type.SCALAR)
+                    .setRole(memRole)
+                    .setScalar(Value.Scalar.newBuilder().setValue(taskMem - containerCpus)))
             .setData(taskData)
             .setExecutor(executor)
             .build();

--- a/src/main/java/org/apache/mesos/hadoop/Utils.java
+++ b/src/main/java/org/apache/mesos/hadoop/Utils.java
@@ -1,21 +1,37 @@
+
 package org.apache.mesos.hadoop;
 
 import javax.xml.transform.*;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-import java.io.StringReader;
-import java.io.StringWriter;
+import java.io.*;
+
+import com.google.protobuf.ByteString;
+import org.apache.hadoop.conf.Configuration;
 
 public class Utils {
+
   public static String formatXml(String source) throws TransformerException {
     Source xmlInput = new StreamSource(new StringReader(source));
     StringWriter stringWriter = new StringWriter();
     StreamResult xmlOutput = new StreamResult(stringWriter);
+
     TransformerFactory transformerFactory = TransformerFactory.newInstance();
     transformerFactory.setAttribute("indent-number", 2);
+
     Transformer transformer = transformerFactory.newTransformer();
     transformer.setOutputProperty(OutputKeys.INDENT, "yes");
     transformer.transform(xmlInput, xmlOutput);
+
     return xmlOutput.getWriter().toString();
+  }
+
+  public static ByteString confToBytes(Configuration conf) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    conf.write(new DataOutputStream(baos));
+    baos.flush();
+
+    byte[] bytes = baos.toByteArray();
+    return ByteString.copyFrom(bytes);
   }
 }


### PR DESCRIPTION
This pull request introduces the ability to revoke slots from a running TaskTracker once it becomes idle. It contributes to solving #32 (map/reduce slot deadlock) as the cluster is able to remove slots that are idle and launch more when needed, avoid a deadlock situation (when resources *are* available).

**TLDR; The JobTracker / Mesos Framework is able to launch and kill map and reduce slots in the cluster as they become idle, to make better use of those resources.**

Essentially, what we've done here is separate the TaskTracker process from the slots. This means launching two mesos tasks attached to the same executor, one for the TaskTracker (as a task with potentially no resources) and another task which can be killed to free up mesos resources while keeping the TaskTracker itself alive. We attach the resources for "revokable" slots to the second task, reserving the ability to free up resources later on.

*Note: This is kind of hacky, and is no where near worthy of testing in production yet. Working progress!*

### How does it work?

Given the use case, I am only dealing with the situation where a running TaskTracker is completely idle. For example, if we launch 10 task trackers with only map slots and 5 with only reduce slots, while the reduce phase is running the map slots (and resources associated with them) can become completely idle. These slots can be killed, as long as the TaskTracker is alive to serve map output to the reducer. It _seems_ hadoop copes perfectly fine with TaskTrackers that have zero slots, too.

If we kill all map slots, we introduce potential failure cases where a node serving map data fails, and there are no map slots to re-compute the data. This is skirted around by only revoking a percentage of map slots from each TaskTracker (`remaining = max(slots - (slots * 0.9), 1)` by default).

Once a TaskTracker becomes alive, we check the "idleness" of the slots every 5 seconds, and if the while TaskTracker has no occupied slots for 5 checks, the next time round we'll revoke its slots. Currently the whole task tracker has to be idle for 30 seconds for slots to be revoked.

- [x] Make it work properly
- [x] Rebase all my nasty commits away
- [x] Configuration, configuration, configuration
- [x] Do all of the todos

I'd be very interested to hear what the community thinks of the solution. There's no doubt something obvious I have missed, but worth discussing the idea.