### PR TITLE
 If no mapred.mesos.executor.uri is set, rely on mapred.mesos.executor directory, if set

### DIFF
--- a/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
@@ -51,7 +51,7 @@ public class MesosExecutor implements Executor {
 
     // Set the mapred.local directory inside the executor sandbox, so that
     // different TaskTrackers on the same host do not step on each other.
-    conf.set("mapred.local.dir", System.getProperty("user.dir") + "/mapred");
+    conf.set("mapred.local.dir", System.getenv("MESOS_DIRECTORY") + "/mapred");
 
     return conf;
   }


### PR DESCRIPTION
This patch lets one omit the hadoop URI and instead rely on a directory location where the hadoop distribution can be found. This has as an advantage that the distribution does not need to be downloaded and extracted for every tasktracker.

(as talked about in #42 )