### PR TITLE
Use MESOS_NATIVE_JAVA_LIBRARY  in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ to the Mesos native library.
 On Linux:
 
 ```
-$ MESOS_NATIVE_LIBRARY=/path/to/libmesos.so hadoop jobtracker
+$ MESOS_NATIVE_JAVA_LIBRARY=/path/to/libmesos.so hadoop jobtracker
 ```
 
 And on OS X:
 
 ```
-$ MESOS_NATIVE_LIBRARY=/path/to/libmesos.dylib hadoop jobtracker
+$ MESOS_NATIVE_JAVA_LIBRARY=/path/to/libmesos.dylib hadoop jobtracker
 ```
 
 > **NOTE: You do not need to worry about distributing your Hadoop


### PR DESCRIPTION
Warning: MESOS_NATIVE_LIBRARY is deprecated, use MESOS_NATIVE_JAVA_LIBRARY instead. Future releases will not support JNI bindings via MESOS_NATIVE_LIBRARY.