### PR TITLE
Improvement for MesosScheduler, cleanups and lint removal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.apache.mesos</groupId>
     <artifactId>hadoop-mesos</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1-SNAPSHOT</version>
 
     <properties>
         <encoding>UTF-8</encoding>
@@ -15,6 +15,7 @@
         <!-- runtime deps versions -->
         <commons-logging.version>1.1.3</commons-logging.version>
         <commons-httpclient.version>3.1</commons-httpclient.version>
+        <!--<hadoop-client.version>2.6.0-mr1-cdh5.4.0</hadoop-client.version>-->
         <hadoop-client.version>2.5.0-mr1-cdh5.2.0</hadoop-client.version>
         <mesos.version>0.21.0</mesos.version>
         <protobuf.version>2.5.0</protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.apache.mesos</groupId>
     <artifactId>hadoop-mesos</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.1.0</version>
 
     <properties>
         <encoding>UTF-8</encoding>
@@ -160,7 +160,14 @@
                     </execution>
                 </executions>
             </plugin>
-        </plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.1</version>
+                <configuration>
+
+                </configuration>
+            </plugin></plugins>
     </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
         <!-- runtime deps versions -->
         <commons-logging.version>1.1.3</commons-logging.version>
         <commons-httpclient.version>3.1</commons-httpclient.version>
-        <!--<hadoop-client.version>2.6.0-mr1-cdh5.4.0</hadoop-client.version>-->
         <hadoop-client.version>2.5.0-mr1-cdh5.2.0</hadoop-client.version>
         <mesos.version>0.21.0</mesos.version>
         <protobuf.version>2.5.0</protobuf.version>

--- a/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
@@ -191,9 +191,10 @@ public class MesosExecutor implements Executor {
   }
 
   /**
-   * This is a hack to over
-   * @param tracker
-   * @param name
+   * This is a hack to overcome lack of accessibility of the launcher. Will solicit feedback from Hadoop list.
+   * 
+   * @param tracker tracker with launcher we want to kill
+   * @param name name of the field containing the launcher
    * @throws NoSuchFieldException
    * @throws IllegalAccessException
    */

--- a/src/main/java/org/apache/hadoop/mapred/MesosScheduler.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosScheduler.java
@@ -36,42 +36,44 @@ public class MesosScheduler extends TaskScheduler implements Scheduler {
   public static final double SLOT_CPUS_DEFAULT = 1; // 1 cores.
   public static final int SLOT_DISK_DEFAULT = 1024; // 1 GB.
   public static final int SLOT_JVM_HEAP_DEFAULT = 1024; // 1024MB.
+
   public static final double TASKTRACKER_CPUS_DEFAULT = 1.0; // 1 core.
   public static final int TASKTRACKER_MEM_DEFAULT = 1024; // 1 GB.
   public static final int TASKTRACKER_DISK_DEFAULT = 1024; // 1 GB.
+
   // The default behavior in Hadoop is to use 4 slots per TaskTracker:
   public static final int MAP_SLOTS_DEFAULT = 2;
   public static final int REDUCE_SLOTS_DEFAULT = 2;
-  // The amount of time to wait for task trackers to launch before
-  // giving up.
+
+  // The amount of time to wait for task trackers to launch before giving up.
   public static final long LAUNCH_TIMEOUT_MS = 300000; // 5 minutes
   public static final long PERIODIC_MS = 300000; // 5 minutes
   public static final long DEFAULT_IDLE_CHECK_INTERVAL = 5; // 5 seconds
+
   // Destroy task trackers after being idle for N idle checks
   public static final long DEFAULT_IDLE_REVOCATION_CHECKS = 5;
-  private SchedulerDriver driver;
+  public Metrics metrics;
 
   protected TaskScheduler taskScheduler;
   protected JobTracker jobTracker;
   protected Configuration conf;
   protected File stateFile;
+
   // Count of the launched trackers for TaskID generation.
   protected long launchedTrackers = 0;
+
   // Use a fixed slot allocation policy?
   protected boolean policyIsFixed = false;
   protected ResourcePolicy policy;
 
   protected boolean enableMetrics = false;
-  public Metrics metrics;
 
   // Maintains a mapping from {tracker host:port -> MesosTracker}.
   // Used for tracking the slots of each TaskTracker and the corresponding
   // Mesos TaskID.
-  protected Map<HttpHost, MesosTracker> mesosTrackers =
-    new ConcurrentHashMap<HttpHost, MesosTracker>();
+  protected Map<HttpHost, MesosTracker> mesosTrackers = new ConcurrentHashMap<>();
 
-  protected final ScheduledExecutorService timerScheduler =
-       Executors.newScheduledThreadPool(1);
+  protected final ScheduledExecutorService timerScheduler = Executors.newScheduledThreadPool(1);
 
   protected JobInProgressListener jobListener = new JobInProgressListener() {
     @Override
@@ -107,8 +109,7 @@ public class MesosScheduler extends TaskScheduler implements Scheduler {
         for (String hostname : flakyTrackers) {
           for (MesosTracker mesosTracker : mesosTrackers.values()) {
             if (mesosTracker.host.getHostName().startsWith(hostname)) {
-              LOG.info("Killing Mesos task: " + mesosTracker.taskId + " on host "
-                  + mesosTracker.host + " because it has been marked as flaky");
+              LOG.info("Killing Mesos task: " + mesosTracker.taskId + " on host " + mesosTracker.host + " because it has been marked as flaky");
               if (metrics != null) {
                 metrics.flakyTrackerKilledMeter.mark();
               }
@@ -131,16 +132,14 @@ public class MesosScheduler extends TaskScheduler implements Scheduler {
         LOG.info("Completed job : " + job.getJobID());
 
         // Remove the task from the map.
-        final Set<HttpHost> trackers = new HashSet<HttpHost>(mesosTrackers.keySet());
+        final Set<HttpHost> trackers = new HashSet<>(mesosTrackers.keySet());
         for (HttpHost tracker : trackers) {
           MesosTracker mesosTracker = mesosTrackers.get(tracker);
           mesosTracker.jobs.remove(job.getJobID());
 
-          // If the TaskTracker doesn't have any running job tasks assigned,
-          // kill it.
+          // If the TaskTracker doesn't have any running job tasks assigned, kill it.
           if (mesosTracker.jobs.isEmpty() && mesosTracker.active) {
-            LOG.info("Killing Mesos task: " + mesosTracker.taskId + " on host "
-                + mesosTracker.host + " because it is no longer needed");
+            LOG.info("Killing Mesos task: " + mesosTracker.taskId + " on host " + mesosTracker.host + " because it is no longer needed");
 
             killTracker(mesosTracker);
           }
@@ -148,147 +147,10 @@ public class MesosScheduler extends TaskScheduler implements Scheduler {
       }
     }
   };
+  private SchedulerDriver driver;
 
-  // TaskScheduler methods.
-  @Override
-  public synchronized void start() throws IOException {
-    conf = getConf();
-    String taskTrackerClass = conf.get("mapred.mesos.taskScheduler",
-        "org.apache.hadoop.mapred.JobQueueTaskScheduler");
+  // --------------------- Interface Scheduler ---------------------
 
-    try {
-      taskScheduler =
-        (TaskScheduler) Class.forName(taskTrackerClass).newInstance();
-      taskScheduler.setConf(conf);
-      taskScheduler.setTaskTrackerManager(taskTrackerManager);
-    } catch (ClassNotFoundException e) {
-      LOG.fatal("Failed to initialize the TaskScheduler", e);
-      System.exit(1);
-    } catch (InstantiationException e) {
-      LOG.fatal("Failed to initialize the TaskScheduler", e);
-      System.exit(1);
-    } catch (IllegalAccessException e) {
-      LOG.fatal("Failed to initialize the TaskScheduler", e);
-      System.exit(1);
-    }
-
-    // Add the job listener to get job related updates.
-    taskTrackerManager.addJobInProgressListener(jobListener);
-
-    LOG.info("Starting MesosScheduler");
-    jobTracker = (JobTracker) super.taskTrackerManager;
-
-    String master = conf.get("mapred.mesos.master", "local");
-
-    try {
-      FrameworkInfo frameworkInfo = FrameworkInfo
-        .newBuilder()
-        .setUser("") // Let Mesos fill in the user.
-        .setCheckpoint(conf.getBoolean("mapred.mesos.checkpoint", false))
-        .setRole(conf.get("mapred.mesos.role", "*"))
-        .setName("Hadoop: (RPC port: " + jobTracker.port + ","
-                 + " WebUI port: " + jobTracker.infoPort + ")").build();
-
-      driver = new MesosSchedulerDriver(this, frameworkInfo, master);
-      driver.start();
-    } catch (Exception e) {
-      // If the MesosScheduler can't be loaded, the JobTracker won't be useful
-      // at all, so crash it now so that the user notices.
-      LOG.fatal("Failed to start MesosScheduler", e);
-      System.exit(1);
-    }
-
-    String file = conf.get("mapred.mesos.state.file", "");
-    if (!file.equals("")) {
-      this.stateFile = new File(file);
-    }
-
-    policyIsFixed = conf.getBoolean("mapred.mesos.scheduler.policy.fixed",
-        policyIsFixed);
-
-    if (policyIsFixed) {
-      policy = new ResourcePolicyFixed(this);
-    } else {
-      policy = new ResourcePolicyVariable(this);
-    }
-
-    enableMetrics = conf.getBoolean("mapred.mesos.metrics.enabled",
-        enableMetrics);
-
-    if (enableMetrics) {
-      metrics = new Metrics(conf);
-    }
-
-    taskScheduler.start();
-  }
-
-  @Override
-  public synchronized void terminate() throws IOException {
-    try {
-      LOG.info("Stopping MesosScheduler");
-      driver.stop();
-    } catch (Exception e) {
-      LOG.error("Failed to stop Mesos scheduler", e);
-    }
-
-    taskScheduler.terminate();
-  }
-
-  @Override
-  public void checkJobSubmission(JobInProgress job) throws IOException {
-    taskScheduler.checkJobSubmission(job);
-  }
-
-  @Override
-  public List<Task> assignTasks(TaskTracker taskTracker)
-      throws IOException {
-    HttpHost tracker = new HttpHost(taskTracker.getStatus().getHost(),
-        taskTracker.getStatus().getHttpPort());
-
-    if (!mesosTrackers.containsKey(tracker)) {
-      LOG.info("Unknown/exited TaskTracker: " + tracker + ". ");
-      return null;
-    }
-
-    MesosTracker mesosTracker = mesosTrackers.get(tracker);
-
-    // Make sure we're not asked to assign tasks to any task trackers that have
-    // been stopped. This could happen while the task tracker has not been
-    // removed from the cluster e.g still in the heartbeat timeout period.
-    synchronized (this) {
-      if (mesosTracker.stopped) {
-        LOG.info("Asked to assign tasks to stopped tracker " + tracker + ".");
-        return null;
-      }
-    }
-
-    // Let the underlying task scheduler do the actual task scheduling.
-    List<Task> tasks = taskScheduler.assignTasks(taskTracker);
-
-    // The Hadoop Fair Scheduler is known to return null.
-    if (tasks == null) {
-      return null;
-    }
-
-    // Keep track of which TaskTracker contains which tasks.
-    for (Task task : tasks) {
-      mesosTracker.jobs.add(task.getJobID());
-    }
-
-    return tasks;
-  }
-
-  @Override
-  public synchronized Collection<JobInProgress> getJobs(String queueName) {
-    return taskScheduler.getJobs(queueName);
-  }
-
-  @Override
-  public synchronized void refresh() throws IOException {
-    taskScheduler.refresh();
-  }
-
-  // Mesos Scheduler methods.
   // These are synchronized, where possible. Some of these methods need to access the
   // JobTracker, which can lead to a deadlock:
   // See: https://issues.apache.org/jira/browse/MESOS-429
@@ -300,85 +162,30 @@ public class MesosScheduler extends TaskScheduler implements Scheduler {
   // state across our Scheduler and TaskScheduler implementations, and provide
   // atomic operations as needed.
   @Override
-  public synchronized void registered(SchedulerDriver schedulerDriver,
-                                      FrameworkID frameworkID, MasterInfo masterInfo) {
-    LOG.info("Registered as " + frameworkID.getValue()
-        + " with master " + masterInfo);
+  public synchronized void registered(SchedulerDriver schedulerDriver, FrameworkID frameworkID, MasterInfo masterInfo) {
+    LOG.info("Registered as " + frameworkID.getValue() + " with master " + masterInfo);
   }
 
   @Override
-  public synchronized void reregistered(SchedulerDriver schedulerDriver,
-                                        MasterInfo masterInfo) {
+  public synchronized void reregistered(SchedulerDriver schedulerDriver, MasterInfo masterInfo) {
     LOG.info("Re-registered with master " + masterInfo);
-  }
-
-  public void killTracker(MesosTracker tracker) {
-    if (metrics != null) {
-      metrics.killMeter.mark();
-    }
-    synchronized (this) {
-      driver.killTask(tracker.taskId);
-    }
-    tracker.stop();
-    if (mesosTrackers.get(tracker.host) == tracker) {
-      mesosTrackers.remove(tracker.host);
-    }
-  }
-
-  public synchronized void scheduleTimer(Runnable command,
-                                         long delay,
-                                         TimeUnit unit) {
-    timerScheduler.schedule(command, delay, unit);
-  }
-
-  // For some reason, pendingMaps() and pendingReduces() doesn't return the
-  // values we expect. We observed negative values, which may be related to
-  // https://issues.apache.org/jira/browse/MAPREDUCE-1238. Below is the
-  // algorithm that is used to calculate the pending tasks within the Hadoop
-  // JobTracker sources (see 'printTaskSummary' in
-  // src/org/apache/hadoop/mapred/jobdetails_jsp.java).
-  public int getPendingTasks(TaskInProgress[] tasks) {
-    int totalTasks = tasks.length;
-    int runningTasks = 0;
-    int finishedTasks = 0;
-    int killedTasks = 0;
-    for (int i = 0; i < totalTasks; ++i) {
-      TaskInProgress task = tasks[i];
-      if (task == null) {
-        continue;
-      }
-      if (task.isComplete()) {
-        finishedTasks += 1;
-      } else if (task.isRunning()) {
-        runningTasks += 1;
-      } else if (task.wasKilled()) {
-        killedTasks += 1;
-      }
-    }
-    int pendingTasks = totalTasks - runningTasks - killedTasks - finishedTasks;
-    return pendingTasks;
   }
 
   // This method uses explicit synchronization in order to avoid deadlocks when
   // accessing the JobTracker.
   @Override
-  public void resourceOffers(SchedulerDriver schedulerDriver,
-                             List<Offer> offers) {
+  public void resourceOffers(SchedulerDriver schedulerDriver, List<Offer> offers) {
     policy.resourceOffers(schedulerDriver, offers);
   }
 
   @Override
-  public synchronized void offerRescinded(SchedulerDriver schedulerDriver,
-                                          OfferID offerID) {
+  public synchronized void offerRescinded(SchedulerDriver schedulerDriver, OfferID offerID) {
     LOG.warn("Rescinded offer: " + offerID.getValue());
   }
 
   @Override
-  public synchronized void statusUpdate(SchedulerDriver schedulerDriver,
-                                        Protos.TaskStatus taskStatus) {
-    LOG.info("Status update of " + taskStatus.getTaskId().getValue()
-        + " to " + taskStatus.getState().name()
-        + " with message " + taskStatus.getMessage());
+  public synchronized void statusUpdate(SchedulerDriver schedulerDriver, Protos.TaskStatus taskStatus) {
+    LOG.info("Status update of " + taskStatus.getTaskId().getValue() + " to " + taskStatus.getState().name() + " with message " + taskStatus.getMessage());
 
     // Remove the TaskTracker if the corresponding Mesos task has reached a
     // terminal state.
@@ -388,7 +195,7 @@ public class MesosScheduler extends TaskScheduler implements Scheduler {
       case TASK_KILLED:
       case TASK_LOST:
         // Make a copy to iterate over keys and delete values.
-        Set<HttpHost> trackers = new HashSet<HttpHost>(mesosTrackers.keySet());
+        Set<HttpHost> trackers = new HashSet<>(mesosTrackers.keySet());
 
         // Remove the task from the map.
         for (HttpHost tracker : trackers) {
@@ -417,11 +224,8 @@ public class MesosScheduler extends TaskScheduler implements Scheduler {
   }
 
   @Override
-  public synchronized void frameworkMessage(SchedulerDriver schedulerDriver,
-                                            ExecutorID executorID, SlaveID slaveID, byte[] bytes) {
-    LOG.info("Framework Message of " + bytes.length + " bytes"
-        + " from executor " + executorID.getValue()
-        + " on slave " + slaveID.getValue());
+  public synchronized void frameworkMessage(SchedulerDriver schedulerDriver, ExecutorID executorID, SlaveID slaveID, byte[] bytes) {
+    LOG.info("Framework Message of " + bytes.length + " bytes" + " from executor " + executorID.getValue() + " on slave " + slaveID.getValue());
   }
 
   @Override
@@ -430,20 +234,179 @@ public class MesosScheduler extends TaskScheduler implements Scheduler {
   }
 
   @Override
-  public synchronized void slaveLost(SchedulerDriver schedulerDriver,
-                                     SlaveID slaveID) {
+  public synchronized void slaveLost(SchedulerDriver schedulerDriver, SlaveID slaveID) {
     LOG.warn("Slave lost: " + slaveID.getValue());
   }
 
   @Override
-  public synchronized void executorLost(SchedulerDriver schedulerDriver,
-                                        ExecutorID executorID, SlaveID slaveID, int status) {
-    LOG.warn("Executor " + executorID.getValue()
-        + " lost with status " + status + " on slave " + slaveID);
+  public synchronized void executorLost(SchedulerDriver schedulerDriver, ExecutorID executorID, SlaveID slaveID, int status) {
+    LOG.warn("Executor " + executorID.getValue() + " lost with status " + status + " on slave " + slaveID);
   }
 
   @Override
   public synchronized void error(SchedulerDriver schedulerDriver, String s) {
     LOG.error("Error from scheduler driver: " + s);
+  }
+
+  @Override
+  public List<Task> assignTasks(TaskTracker taskTracker) throws IOException {
+
+    // Let the underlying task scheduler do the actual task scheduling.
+    List<Task> tasks = taskScheduler.assignTasks(taskTracker);
+
+    // The Hadoop Fair Scheduler is known to return null.
+    if (tasks != null) {
+      HttpHost tracker = new HttpHost(taskTracker.getStatus().getHost(), taskTracker.getStatus().getHttpPort());
+      MesosTracker mesosTracker = mesosTrackers.get(tracker);
+      synchronized (this) {
+        if (mesosTracker != null) {
+          if (mesosTracker.stopped) {
+            // Make sure we're not asked to assign tasks to any task trackers that have
+            // been stopped. This could happen while the task tracker has not been
+            // removed from the cluster e.g still in the heartbeat timeout period.
+            LOG.info("Asked to assign tasks to stopped tracker " + tracker + ".");
+            return null;
+          } else {
+            // Keep track of which TaskTracker contains which tasks.
+            for (Task task : tasks) {
+              mesosTracker.jobs.add(task.getJobID());
+            }
+          }
+        }
+      }
+    }
+
+    return tasks;
+  }
+
+  @Override
+  public void checkJobSubmission(JobInProgress job) throws IOException {
+    taskScheduler.checkJobSubmission(job);
+  }
+
+  @Override
+  public synchronized Collection<JobInProgress> getJobs(String queueName) {
+    return taskScheduler.getJobs(queueName);
+  }
+
+  /**
+   * For some reason, pendingMaps() and pendingReduces() doesn't return the values we expect. We observed negative
+   * values, which may be related to https://issues.apache.org/jira/browse/MAPREDUCE-1238. Below is the algorithm
+   * that is used to calculate the pending tasks within the Hadoop JobTracker sources (see 'printTaskSummary' in
+   * src/org/apache/hadoop/mapred/jobdetails_jsp.java).
+   *
+   * @param tasks
+   * @return
+   */
+  public int getPendingTasks(TaskInProgress[] tasks) {
+    int totalTasks = tasks.length;
+    int runningTasks = 0;
+    int finishedTasks = 0;
+    int killedTasks = 0;
+    for (TaskInProgress task : tasks) {
+      if (task == null) {
+        continue;
+      }
+      if (task.isComplete()) {
+        finishedTasks += 1;
+      } else if (task.isRunning()) {
+        runningTasks += 1;
+      } else if (task.wasKilled()) {
+        killedTasks += 1;
+      }
+    }
+    return totalTasks - runningTasks - killedTasks - finishedTasks;
+  }
+
+  public void killTracker(MesosTracker tracker) {
+    if (metrics != null) {
+      metrics.killMeter.mark();
+    }
+    synchronized (this) {
+      driver.killTask(tracker.taskId);
+    }
+    tracker.stop();
+    if (mesosTrackers.get(tracker.host) == tracker) {
+      mesosTrackers.remove(tracker.host);
+    }
+  }
+
+  @Override
+  public synchronized void refresh() throws IOException {
+    taskScheduler.refresh();
+  }
+
+  public synchronized void scheduleTimer(Runnable command, long delay, TimeUnit unit) {
+    timerScheduler.schedule(command, delay, unit);
+  }
+
+  // TaskScheduler methods.
+  @Override
+  public synchronized void start() throws IOException {
+    conf = getConf();
+    String taskTrackerClass = conf.get("mapred.mesos.taskScheduler", "org.apache.hadoop.mapred.JobQueueTaskScheduler");
+
+    try {
+      taskScheduler = (TaskScheduler) Class.forName(taskTrackerClass).newInstance();
+      taskScheduler.setConf(conf);
+      taskScheduler.setTaskTrackerManager(taskTrackerManager);
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+      LOG.fatal("Failed to initialize the TaskScheduler", e);
+      System.exit(1);
+    }
+
+    // Add the job listener to get job related updates.
+    taskTrackerManager.addJobInProgressListener(jobListener);
+
+    LOG.info("Starting MesosScheduler");
+    jobTracker = (JobTracker) super.taskTrackerManager;
+
+    String master = conf.get("mapred.mesos.master", "local");
+
+    try {
+      FrameworkInfo frameworkInfo = FrameworkInfo.newBuilder().setUser("") // Let Mesos fill in the user.
+          .setCheckpoint(conf.getBoolean("mapred.mesos.checkpoint", false)).setRole(conf.get("mapred.mesos.role", "*")).setName("Hadoop: (RPC port: " + jobTracker.port + "," + " WebUI port: " + jobTracker.infoPort + ")").build();
+
+      driver = new MesosSchedulerDriver(this, frameworkInfo, master);
+      driver.start();
+    } catch (Exception e) {
+      // If the MesosScheduler can't be loaded, the JobTracker won't be useful
+      // at all, so crash it now so that the user notices.
+      LOG.fatal("Failed to start MesosScheduler", e);
+      System.exit(1);
+    }
+
+    String file = conf.get("mapred.mesos.state.file", "");
+    if (!file.equals("")) {
+      this.stateFile = new File(file);
+    }
+
+    policyIsFixed = conf.getBoolean("mapred.mesos.scheduler.policy.fixed", policyIsFixed);
+
+    if (policyIsFixed) {
+      policy = new ResourcePolicyFixed(this);
+    } else {
+      policy = new ResourcePolicyVariable(this);
+    }
+
+    enableMetrics = conf.getBoolean("mapred.mesos.metrics.enabled", enableMetrics);
+
+    if (enableMetrics) {
+      metrics = new Metrics(conf);
+    }
+
+    taskScheduler.start();
+  }
+
+  @Override
+  public synchronized void terminate() throws IOException {
+    try {
+      LOG.info("Stopping MesosScheduler");
+      driver.stop();
+    } catch (Exception e) {
+      LOG.error("Failed to stop Mesos scheduler", e);
+    }
+
+    taskScheduler.terminate();
   }
 }

--- a/src/main/java/org/apache/hadoop/mapred/ResourcePolicyFixed.java
+++ b/src/main/java/org/apache/hadoop/mapred/ResourcePolicyFixed.java
@@ -1,18 +1,18 @@
 package org.apache.hadoop.mapred;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
+/**
+ * @todo What is the difference between variable and fixed resource policy?
+ */
 public class ResourcePolicyFixed extends ResourcePolicy {
-
-  public static final Log LOG = LogFactory.getLog(ResourcePolicyFixed.class);
-
   public ResourcePolicyFixed(MesosScheduler scheduler) {
     super(scheduler);
   }
 
-  // This method computes the number of slots to launch for this offer, and
-  // returns true if the offer is sufficient.
+  /**
+   * Computes the number of slots to launch for this offer
+   *
+   * @return true if the offer is sufficient
+   */
   @Override
   public boolean computeSlots() {
     mapSlots = mapSlotsMax;
@@ -24,9 +24,6 @@ public class ResourcePolicyFixed extends ResourcePolicy {
     slots = (int) Math.min(slots, (disk - containerDisk) / slotDisk);
 
     // Is this offer too small for even the minimum slots?
-    if (slots < mapSlots + reduceSlots || slots < 1) {
-      return false;
-    }
-    return true;
+    return slots >= 1 && slots >= mapSlots + reduceSlots;
   }
 }

--- a/src/main/java/org/apache/hadoop/mapred/ResourcePolicyVariable.java
+++ b/src/main/java/org/apache/hadoop/mapred/ResourcePolicyVariable.java
@@ -1,61 +1,62 @@
 package org.apache.hadoop.mapred;
 
+/**
+ * @todo What is the difference between variable and fixed resource policy?
+ */
 public class ResourcePolicyVariable extends ResourcePolicy {
-    public ResourcePolicyVariable(MesosScheduler scheduler) {
-      super(scheduler);
-    }
-
-    // This method computes the number of slots to launch for this offer, and
-    // returns true if the offer is sufficient.
-    @Override
-    public boolean computeSlots() {
-      // What's the minimum number of map and reduce slots we should try to
-      // launch?
-      mapSlots = 0;
-      reduceSlots = 0;
-
-      // Determine how many slots we can allocate.
-      int slots = mapSlotsMax + reduceSlotsMax;
-      slots = (int) Math.min(slots, (cpus - containerCpus) / slotCpus);
-      slots = (int) Math.min(slots, (mem - containerMem) / slotMem);
-      slots = (int) Math.min(slots, (disk - containerDisk) / slotDisk);
-
-      // Is this offer too small for even the minimum slots?
-      if (slots < 1) {
-        return false;
-      }
-
-      // Is the number of slots we need sufficiently small? If so, we can
-      // allocate exactly the number we need.
-      if (slots >= neededMapSlots + neededReduceSlots && neededMapSlots <
-          mapSlotsMax && neededReduceSlots < reduceSlotsMax) {
-        mapSlots = neededMapSlots;
-        reduceSlots = neededReduceSlots;
-      } else {
-        // Allocate slots fairly for this resource offer.
-        double mapFactor = (double) neededMapSlots / (neededMapSlots + neededReduceSlots);
-        double reduceFactor = (double) neededReduceSlots / (neededMapSlots + neededReduceSlots);
-        // To avoid map/reduce slot starvation, don't allow more than 50%
-        // spread between map/reduce slots when we need both mappers and
-        // reducers.
-        if (neededMapSlots > 0 && neededReduceSlots > 0) {
-          if (mapFactor < 0.25) {
-            mapFactor = 0.25;
-          } else if (mapFactor > 0.75) {
-            mapFactor = 0.75;
-          }
-          if (reduceFactor < 0.25) {
-            reduceFactor = 0.25;
-          } else if (reduceFactor > 0.75) {
-            reduceFactor = 0.75;
-          }
-        }
-        mapSlots = Math.min(Math.min((long)Math.max(Math.round(mapFactor * slots), 1), mapSlotsMax), neededMapSlots);
-
-        // The remaining slots are allocated for reduces.
-        slots -= mapSlots;
-        reduceSlots = Math.min(Math.min(slots, reduceSlotsMax), neededReduceSlots);
-      }
-      return true;
-    }
+  public ResourcePolicyVariable(MesosScheduler scheduler) {
+    super(scheduler);
   }
+
+  /**
+   * Computes the number of slots to launch for this offer
+   *
+   * @return true if the offer is sufficient
+   */
+  @Override
+  public boolean computeSlots() {
+    // What's the minimum number of map and reduce slots we should try to
+    // launch?
+    mapSlots = 0;
+    reduceSlots = 0;
+
+    // Determine how many slots we can allocate.
+    int slots = mapSlotsMax + reduceSlotsMax;
+    slots = (int) Math.min(slots, (cpus - containerCpus) / slotCpus);
+    slots = (int) Math.min(slots, (mem - containerMem) / slotMem);
+    slots = (int) Math.min(slots, (disk - containerDisk) / slotDisk);
+
+    // Is this offer too small for even the minimum slots?
+    if (slots < 1) {
+      return false;
+    }
+
+    // Is the number of slots we need sufficiently small? If so, we can
+    // allocate exactly the number we need.
+    if (slots >= neededMapSlots + neededReduceSlots
+        && neededMapSlots < mapSlotsMax
+        && neededReduceSlots < reduceSlotsMax) {
+      mapSlots = neededMapSlots;
+      reduceSlots = neededReduceSlots;
+    } else {
+      // Allocate slots fairly for this resource offer.
+      double mapFactor = (double) neededMapSlots / (neededMapSlots + neededReduceSlots);
+      // To avoid map/reduce slot starvation, don't allow more than 50%
+      // spread between map/reduce slots when we need both mappers and
+      // reducers.
+      if (neededMapSlots > 0 && neededReduceSlots > 0) {
+        if (mapFactor < 0.25) {
+          mapFactor = 0.25;
+        } else if (mapFactor > 0.75) {
+          mapFactor = 0.75;
+        }
+      }
+      mapSlots = Math.min(Math.min(Math.max(Math.round(mapFactor * slots), 1), mapSlotsMax), neededMapSlots);
+
+      // The remaining slots are allocated for reduces.
+      slots -= mapSlots;
+      reduceSlots = Math.min(Math.min(slots, reduceSlotsMax), neededReduceSlots);
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
In my deployment of 2.6.0-mr1-cdh5.4.0, I had a problem where "2015-05-08 03:33:24,421 INFO org.apache.hadoop.mapred.MesosScheduler: Unknown/exited TaskTracker: http://10.211.55.16:50060. " was being emitted 3-5 times a second. I don't have a JWDP connection figured out to see what the messages were, but I'm guessing there is an internal housekeeping job that is used internally. This implementation allows that to happen quietly.

* Restructure o.a.h.mapred.MesosScheduler#assignTasks to always pass through tasks, then decide whether they are a Mesos-managed TaskTracker
* ResourcePolicy is abstract for all intents, but it could be instantiated. Make it literally abstract
* A bunch of lint warnings removed
* Rearrange code to be easier to read -- interface implementations commented and methods in order, update some docs to JavaDoc format.
* Update POM version to 0.1.1-SNAPSHOT for additional work.