### PR TITLE
Avoid respawning task trackers constantly when they are idle

### DIFF
--- a/src/main/java/org/apache/hadoop/mapred/MesosScheduler.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosScheduler.java
@@ -324,10 +324,11 @@ public class MesosScheduler extends TaskScheduler implements Scheduler {
     }
     synchronized (this) {
       driver.killTask(tracker.taskId);
-    }
-    tracker.stop();
-    if (mesosTrackers.get(tracker.host) == tracker) {
-      mesosTrackers.remove(tracker.host);
+
+      tracker.stop();
+      if (mesosTrackers.get(tracker.host) == tracker) {
+        mesosTrackers.remove(tracker.host);
+      }
     }
   }
 


### PR DESCRIPTION
Previously the "idle check" would be run against all task trackers regardless of whether they have any jobs assigned to them or not. The main MesosScheduler is responsible for cleaning up task trackers once jobs have *finished* so this change stops us performing idle checks on trackers that have no jobs.

Destruction of those task trackers will be handled elsewhere.

This change fixes the observed behaviour of task trackers being killed and respawning continuously when they're waiting for jobs to be scheduled on them (e.g with the min map/reduce slot config option, or the fixed resource policy). Essentially this fixed a case when trackers were killed due to being idle, when they were supposed to be sitting idle.