### PR TITLE
Add support for the native docker containerizer

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -183,7 +183,7 @@ default values.
       Comma separated list of command line arguments to pass directly to the
       docker run invocation. For example...
 
-      "-e,FOO=bar,-e,BAZ=test"
+      "env,FOO=bar,env,BAZ=test"
     </description>
   </property>
   <property>

--- a/configuration.md
+++ b/configuration.md
@@ -142,6 +142,63 @@ default values.
     </description>
   </property>
 
+  <!-- If you're using Mesos Native Docker -->
+  <property>
+    <name>mapred.mesos.docker.image</name>
+    <value>my-registry.com/image/foo:tag</value>
+    <description>
+      If you want the TaskTracker executor processes to start inside Docker containers,
+      specify the docker image here.
+    </description>
+  </property>
+  <property>
+    <name>mapred.mesos.docker.network</name>
+    <value>1</value>
+    <description>
+      Use this option to change the networking configuration for containers. The
+      default here is to use HOST networking (the container shares the network)
+      with the host, no isolation.
+      1 = HOST, 2 = BRIDGE, 3 = NONE;
+    </description>
+  </property>
+  <property>
+    <name>mapred.mesos.docker.privileged</name>
+    <value>false</value>
+    <description>
+      Enable the --privileged option on the executor containers.
+    </description>
+  </property>
+  <property>
+    <name>mapred.mesos.docker.force_pull_image</name>
+    <value>false</value>
+    <description>
+      Tell the mesos slave to always check it has the latest version of the container
+      image before starting the container.
+    </description>
+  </property>
+  <property>
+    <name>mapred.mesos.docker.parameters</name>
+    <value></value>
+    <description>
+      Comma separated list of command line arguments to pass directly to the
+      docker run invocation. For example...
+
+      "-e,FOO=bar,-e,BAZ=test"
+    </description>
+  </property>
+  <property>
+    <name>mapred.mesos.docker.volumes</name>
+    <value></value>
+    <description>
+      Comma separated list of volumes to mount into the container. The format for
+      the volume definition is similar to the docker CLI, for example...
+
+      "/host/path:/container/path:rw" (mount /host/path to /container/path read-write)
+      "/host/path:/container/path:ro" (mount /host/path to /container/path read-only)
+      "/host/path:ro" (mount /host/path to /host/path read-only)
+    </description>
+  </property>
+
   <!-- If you're using a custom Mesos Containerizer -->
   <property>
     <name>mapred.mesos.container.image</name>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <commons-logging.version>1.1.3</commons-logging.version>
         <commons-httpclient.version>3.1</commons-httpclient.version>
         <hadoop-client.version>2.5.0-mr1-cdh5.2.0</hadoop-client.version>
-        <mesos.version>0.21.0</mesos.version>
+        <mesos.version>0.23.1</mesos.version>
         <protobuf.version>2.5.0</protobuf.version>
         <metrics.version>3.1.0</metrics.version>
         <snappy-java.version>1.0.5</snappy-java.version>

--- a/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
+++ b/src/main/java/org/apache/hadoop/mapred/MesosExecutor.java
@@ -58,9 +58,14 @@ public class MesosExecutor implements Executor {
     // to the JobTracker.
     conf.set("slave.host.name", slaveInfo.getHostname());
 
+    String sandbox = System.getenv("MESOS_SANDBOX");
+    if (sandbox == null || sandbox.equals("")) {
+      sandbox = System.getenv("MESOS_DIRECTORY");
+    }
+
     // Set the mapred.local directory inside the executor sandbox, so that
     // different TaskTrackers on the same host do not step on each other.
-    conf.set("mapred.local.dir", System.getenv("MESOS_DIRECTORY") + "/mapred");
+    conf.set("mapred.local.dir", sandbox + "/mapred");
 
     return conf;
   }

--- a/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
+++ b/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
@@ -422,25 +422,10 @@ public class ResourcePolicy {
             commandInfo.addUris(CommandInfo.URI.newBuilder().setValue(uri));
         }
 
-        // Populate ContainerInfo if needed
+        // Populate old-style ContainerInfo if needed
         String containerImage = scheduler.conf.get("mapred.mesos.container.image");
-        String[] containerOptions = scheduler.conf.getStrings("mapred.mesos.container.options");
-
-        if (containerImage != null || (containerOptions != null && containerOptions.length > 0)) {
-          CommandInfo.ContainerInfo.Builder containerInfo =
-              CommandInfo.ContainerInfo.newBuilder();
-
-          if (containerImage != null) {
-            containerInfo.setImage(containerImage);
-          }
-
-          if (containerOptions != null) {
-            for (int i = 0; i < containerOptions.length; i++) {
-              containerInfo.addOptions(containerOptions[i]);
-            }
-          }
-
-          commandInfo.setContainer(containerInfo.build());
+        if (containerImage != null && !containerImage.equals("")) {
+          commandInfo.setContainer(org.apache.mesos.hadoop.Utils.buildContainerInfo(scheduler.conf));
         }
 
         // Create a configuration from the current configuration and

--- a/src/main/java/org/apache/mesos/hadoop/Utils.java
+++ b/src/main/java/org/apache/mesos/hadoop/Utils.java
@@ -9,6 +9,9 @@ import java.io.*;
 import com.google.protobuf.ByteString;
 import org.apache.hadoop.conf.Configuration;
 
+import org.apache.mesos.Protos.CommandInfo;
+import org.apache.mesos.Protos.ContainerInfo;
+
 public class Utils {
 
   public static String formatXml(String source) throws TransformerException {
@@ -33,5 +36,25 @@ public class Utils {
 
     byte[] bytes = baos.toByteArray();
     return ByteString.copyFrom(bytes);
+  }
+
+  public static CommandInfo.ContainerInfo buildContainerInfo(Configuration conf) {
+    String containerImage = conf.get("mapred.mesos.container.image");
+    String[] containerOptions = conf.getStrings("mapred.mesos.container.options");
+
+    CommandInfo.ContainerInfo.Builder containerInfo =
+        CommandInfo.ContainerInfo.newBuilder();
+
+    if (containerImage != null) {
+      containerInfo.setImage(containerImage);
+    }
+
+    if (containerOptions != null) {
+      for (int i = 0; i < containerOptions.length; i++) {
+        containerInfo.addOptions(containerOptions[i]);
+      }
+    }
+
+    return containerInfo.build();
   }
 }

--- a/src/main/java/org/apache/mesos/hadoop/Utils.java
+++ b/src/main/java/org/apache/mesos/hadoop/Utils.java
@@ -107,7 +107,7 @@ public class Utils {
         assert parts.length <= 3;
 
         Volume.Mode mode = Volume.Mode.RW;
-        if (parts[-1].toLowerCase().equals("ro")) {
+        if (parts[parts.length - 1].toLowerCase().equals("ro")) {
           mode = Volume.Mode.RO;
         }
 

--- a/src/main/java/org/apache/mesos/hadoop/Utils.java
+++ b/src/main/java/org/apache/mesos/hadoop/Utils.java
@@ -11,6 +11,7 @@ import org.apache.hadoop.conf.Configuration;
 
 import org.apache.mesos.Protos.CommandInfo;
 import org.apache.mesos.Protos.ContainerInfo;
+import org.apache.mesos.Protos.ContainerInfo.DockerInfo;
 import org.apache.mesos.Protos.Parameter;
 import org.apache.mesos.Protos.Parameters;
 import org.apache.mesos.Protos.Volume;
@@ -63,17 +64,17 @@ public class Utils {
 
   public static ContainerInfo buildDockerContainerInfo(Configuration conf) {
     ContainerInfo.Builder containerInfoBuilder = ContainerInfo.newBuilder();
-    ContainerInfo.DockerInfo.Builder dockerInfoBuilder = ContainerInfo.DockerInfo.newBuilder();
+    DockerInfo.Builder dockerInfoBuilder = DockerInfo.newBuilder();
 
     dockerInfoBuilder.setImage(conf.get("mapred.mesos.docker.image"));
 
     switch (conf.getInt("mapred.mesos.docker.network", 1)) {
       case 1:
-        dockerInfoBuilder.setNetwork(ContainerInfo.DockerInfo.Network.HOST);
+        dockerInfoBuilder.setNetwork(DockerInfo.Network.HOST);
       case 2:
-        dockerInfoBuilder.setNetwork(ContainerInfo.DockerInfo.Network.BRIDGE);
+        dockerInfoBuilder.setNetwork(DockerInfo.Network.BRIDGE);
       case 3:
-        dockerInfoBuilder.setNetwork(ContainerInfo.DockerInfo.Network.NONE);
+        dockerInfoBuilder.setNetwork(DockerInfo.Network.NONE);
     }
 
     dockerInfoBuilder.setPrivileged(conf.getBoolean("mapred.mesos.docker.privileged", false));
@@ -81,7 +82,7 @@ public class Utils {
 
     // Parse out any additional docker CLI params
     String[] params = conf.getStrings("mapred.mesos.docker.parameters");
-    if (params.length > 0) {
+    if (params != null && params.length > 0) {
       assert (params.length % 2) == 0; // Make sure we have an even number of parameters
 
       Parameter.Builder paramBuilder = null;
@@ -99,7 +100,7 @@ public class Utils {
 
     // Parse out any volumes that have been defined
     String[] volumes = conf.getStrings("mapred.mesos.docker.volumes");
-    if (volumes.length > 0) {
+    if (volumes != null && volumes.length > 0) {
       for (int i = 0; i < volumes.length; i++) {
         String[] parts = volumes[i].split(":");
         assert parts.length > 1;

--- a/src/main/java/org/apache/mesos/hadoop/Utils.java
+++ b/src/main/java/org/apache/mesos/hadoop/Utils.java
@@ -107,7 +107,7 @@ public class Utils {
         assert parts.length <= 3;
 
         Volume.Mode mode = Volume.Mode.RW;
-        if (parts[parts.length - 1].toLowerCase().equals("ro")) {
+        if (parts[parts.length - 1].equalsIgnoreCase("ro")) {
           mode = Volume.Mode.RO;
         }
 

--- a/src/main/java/org/apache/mesos/hadoop/Utils.java
+++ b/src/main/java/org/apache/mesos/hadoop/Utils.java
@@ -4,6 +4,7 @@ package org.apache.mesos.hadoop;
 import javax.xml.transform.*;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+import java.lang.IllegalArgumentException;
 import java.io.*;
 
 import com.google.protobuf.ByteString;
@@ -85,7 +86,10 @@ public class Utils {
     // Parse out any additional docker CLI params
     String[] params = conf.getStrings("mapred.mesos.docker.parameters");
     if (params != null && params.length > 0) {
-      assert (params.length % 2) == 0; // Make sure we have an even number of parameters
+      // Make sure we have an even number of parameters
+      if ((params.length % 2) != 0) {
+        throw new IllegalArgumentException("The number of parameters should be even, k/v pairs");
+      }
 
       Parameter.Builder paramBuilder = null;
       for (int i = 0; i < params.length; i++) {
@@ -105,8 +109,10 @@ public class Utils {
     if (volumes != null && volumes.length > 0) {
       for (int i = 0; i < volumes.length; i++) {
         String[] parts = volumes[i].split(":");
-        assert parts.length > 1;
-        assert parts.length <= 3;
+
+        if (parts.length <= 1 || parts.length > 3) {
+          throw new IllegalArgumentException("Invalid volume configuration (host_path:container_path:[rw|ro])");
+        }
 
         Volume.Mode mode = Volume.Mode.RW;
         if (parts[parts.length - 1].equalsIgnoreCase("ro")) {

--- a/src/main/java/org/apache/mesos/hadoop/Utils.java
+++ b/src/main/java/org/apache/mesos/hadoop/Utils.java
@@ -75,6 +75,8 @@ public class Utils {
         dockerInfoBuilder.setNetwork(DockerInfo.Network.BRIDGE);
       case 3:
         dockerInfoBuilder.setNetwork(DockerInfo.Network.NONE);
+      default:
+        dockerInfoBuilder.setNetwork(DockerInfo.Network.HOST);
     }
 
     dockerInfoBuilder.setPrivileged(conf.getBoolean("mapred.mesos.docker.privileged", false));


### PR DESCRIPTION
This is an implementation of #49, adding support for the "new" native docker containerized that mesos has had for almost 18 months. There's a new set of options, which should be used separately from the existing external containerizer configuration options.

Here's an example configuration...

```xml
<property>
  <name>mapred.mesos.docker.image</name>
  <value>my-registry.com/image/foo:tag</value>
</property>
<property>
  <name>mapred.mesos.docker.privileged</name>
  <value>true</value>
</property>
<property>
  <name>mapred.mesos.docker.force_pull_image</name>
  <value>false</value>
</property>
<property>
  <name>mapred.mesos.docker.parameters</name>
  <value>-e,MY_VAR=value</value>
</property>
<property>
  <name>mapred.mesos.docker.volumes</name>
  <value>/host/path:/container/path:rw</value>
</property>
```